### PR TITLE
Codesniffer: update ruleset

### DIFF
--- a/src/codesniffer.xml
+++ b/src/codesniffer.xml
@@ -281,7 +281,6 @@
 	</rule>
 	<rule ref="SlevomatCodingStandard.Classes.ClassStructure">
 		<properties>
-			<property name="enableFinalMethods" value="true"/>
 			<property name="groups" type="array">
 				<element value="uses"/>
 

--- a/src/codesniffer.xml
+++ b/src/codesniffer.xml
@@ -268,6 +268,8 @@
 	<rule ref="SlevomatCodingStandard.PHP.TypeCast"/>
 	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
 	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
+	<rule ref="SlevomatCodingStandard.Classes.PropertyDeclaration"/>
+	<rule ref="SlevomatCodingStandard.Classes.PropertySpacing"/>
 	<rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
 	<rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
 		<properties>


### PR DESCRIPTION
- rule SlevomatCodingStandard.TypeHints.PropertyTypeHintSpacing was removed, use SlevomatCodingStandard.Classes.PropertyDeclaration and SlevomatCodingStandard.Classes.PropertySpacing instead
- property enableFinalMethods was removed in SlevomatCodingStandard.Classes.ClassStructure rule