### PR TITLE
codesniffer: add sniff for 'interface' suffix naming convention

### DIFF
--- a/src/codesniffer.xml
+++ b/src/codesniffer.xml
@@ -27,6 +27,7 @@
 	<rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.NamingConventions.CamelCapsFunctionName"/>
+    <rule ref="Generic.NamingConventions.InterfaceNameSuffix"/>
 	<rule ref="Generic.Files.LineEndings">
 		<properties>
 			<property name="eolChar" value="\n"/>


### PR DESCRIPTION
Už tady bych mohl pomocí `<exclude-pattern>*Factory.php</exclude-pattern>` excludnout factorky. Pokud to tedy není moc specifické pro Nette.